### PR TITLE
[story/TP-94583]: Fix datamapper-do/do-mysql install and compile failures

### DIFF
--- a/dm-do-adapter.gemspec
+++ b/dm-do-adapter.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = DataMapper::DoAdapter::VERSION
   gem.required_ruby_version = '>= 2.7.8'
 
-  gem.add_runtime_dependency('data_objects', ['~> 0.10.6'])
+  gem.add_runtime_dependency('data_objects', ['~> 0.10.17'])
   gem.add_runtime_dependency('dm-core', ['~> 1.3.0.beta'])
 end


### PR DESCRIPTION
# Topic

TargetProcess Link: https://sbf.tpondemand.com/entity/94583

## How to test
* [How to PR](https://github.com/firespring/sbf/blob/master/documentation/guides/processes/pull_requests.md#reviewing-pull-requests)

### Functionality
* Update to use correct version of data_objects gem

### PRs for this story from other repos
* [dm-dev](https://github.com/firespring/dm-dev/pull/4)
* data_mapper - No changes 
* [datamapper-do](https://github.com/firespring/datamapper-do/pull/5)
* [dm-aggregates] - No changes
* [dm-constraints] - No changes
* [dm-core] - No changes
* **dm-do-adapter - This PR**
* [dm-mysql-adapter](https://github.com/firespring/dm-mysql-adapter/pull/4)
* [dm-noisy-failures] - No changes
* [dm-serializer] - No changes
* [dm-sqlite-adapter](https://github.com/firespring/dm-sqlite-adapter/pull/1)
* [dm-timestamps] - No changes
* [dm-transactions] - No changes
* [dm-types] - No changes
* [dm-validations] - No changes